### PR TITLE
Add more parameters to init AttributedString (e.g. bundle)

### DIFF
--- a/Sources/StyledMarkdown/AttributedString.StyledMarkdown.swift
+++ b/Sources/StyledMarkdown/AttributedString.StyledMarkdown.swift
@@ -14,10 +14,19 @@ public extension AttributedString {
     ///   - styleGroup: Style group to be used to apply styling on the markdown.
     init(
         localized: String.LocalizationValue,
-        styleGroup: StyleGroup
+        styleGroup: StyleGroup,
+        options: AttributedString.FormattingOptions = [],
+        table: String? = nil,
+        bundle: Bundle? = nil,
+        locale: Locale? = nil,
+        comment: StaticString? = nil
     ) {
         let attributedString = AttributedString(
             localized: localized,
+            options: options,
+            table: table,
+            bundle: bundle,
+            locale: locale,
             including: \.styledMarkdown
         )
         self = Self.annotateStyles(


### PR DESCRIPTION
If you use it in a swift package, you need to use strings from `bundle: .module`. This PR provides support for specifying other parameters such as the bundle